### PR TITLE
Addition of HTTP method

### DIFF
--- a/bin/log
+++ b/bin/log
@@ -15,6 +15,7 @@ my %opts = (
     user        => $ENV{SUDO_USER} || $ENV{USER},
     do_udp      => 1,
     do_file     => 1,
+    do_http     => 0,
     do_twitter  => 0,
 );
 my $HOME = File::HomeDir->users_home($opts{user});
@@ -45,10 +46,12 @@ GetOptions( \%opts,
     'udp!',
     'twitter!',
     'file!',
+    'http!',
 ) or exit;
 
 $opts{do_udp}     = delete $opts{udp};
 $opts{do_file}    = delete $opts{file};
+$opts{do_http}    = delete $opts{http};
 $opts{do_twitter} = delete $opts{twitter};
 
 my %udp_data = ( irc => 1, port => 9002, host => 'localhost' );
@@ -64,6 +67,7 @@ Options:
     B<--view>       View a log file instead of add to it
     B<--logdir>     Use a different log directory
     B<--twitter>    Send your log entry to Twitter
+    B<--http>       Send your log entry to Http
     B<--no-file>    Skip logging to file
     B<--no-udp>     Skip sending log data over UDP
     B<--udp-data>   Sets UDP data:
@@ -99,6 +103,10 @@ Sets the log directory to use - defaults to F</var/log/sysadmin>.
 =item B<--twitter>, --no-twitter
 
 Whether to send your log entry to Twitter. Default is false.
+
+=item B<--http>, --no-http
+
+Whether to send your log entry via HTTP. Default is false.
 
 =item B<--file>, --no-file
 

--- a/bin/log
+++ b/bin/log
@@ -58,6 +58,10 @@ my %udp_data = ( irc => 1, port => 9002, host => 'localhost' );
 GetOptions( 'udp-data=s' => \%udp_data) or exit;
 $opts{udp} = \%udp_data if $opts{do_udp};
 
+my %http_data = ( http => 1, method => 'post', uri => 'http://localhost' );
+GetOptions( 'http-data=s' => \%http_data) or exit;
+$opts{http} = \%http_data if $opts{do_http};
+
 =head1 SYNOPSIS
 
 B<log> [--date YYYY/MM/DD] [--view] [--version] [--help]
@@ -68,6 +72,9 @@ Options:
     B<--logdir>     Use a different log directory
     B<--twitter>    Send your log entry to Twitter
     B<--http>       Send your log entry to Http
+    B<--http-data>  Sets HTTP data:
+                        - method to send using
+                        - uri to send to
     B<--no-file>    Skip logging to file
     B<--no-udp>     Skip sending log data over UDP
     B<--udp-data>   Sets UDP data:
@@ -107,6 +114,22 @@ Whether to send your log entry to Twitter. Default is false.
 =item B<--http>, --no-http
 
 Whether to send your log entry via HTTP. Default is false.
+
+=item B<--http-data>
+
+Sets data related to HTTP. Specify a single key-value pair:
+
+=over 4
+
+=item * uri - the uri to send to - default is http://localhost
+
+=item * method - the method to send using - default is POST
+
+=back
+
+Use it multiple times to set multiple key-value pairs:
+
+    log --udp-data host=localhost --udp-data port=9002
 
 =item B<--file>, --no-file
 

--- a/lib/App/Sysadmin/Log/Simple.pm
+++ b/lib/App/Sysadmin/Log/Simple.pm
@@ -130,6 +130,7 @@ sub new {
     return bless {
         do_twitter  => $opts{do_twitter} // 0,
         do_file     => $opts{do_file} // 1,
+        do_http     => $opts{do_http} // 0,
         do_udp      => $opts{do_udp} // 1,
         logdir      => $opts{logdir},
         date        => $today,

--- a/lib/App/Sysadmin/Log/Simple.pm
+++ b/lib/App/Sysadmin/Log/Simple.pm
@@ -93,6 +93,17 @@ structure:
         port => 9002,       # What port to send to
     );
 
+=head3 http
+
+A hashref of data regarding HTTP usage. If you don't want to
+send a HTTP message, omit this. Otherwise, it has the following
+structure:
+
+    my %http_data = (
+        uri => 'http://localhost', # What uri to send to
+        method => 'post',          # What method to send using
+    );
+
 =head3 index_preamble
 
 The text to prepend to the index page. Can be anything - by
@@ -137,6 +148,7 @@ sub new {
         user        => $opts{user} || $ENV{SUDO_USER} || $ENV{USER},
         in          => $opts{read_from} || \*STDIN,
         udp         => $opts{udp},
+        http        => $opts{http},
     }, $class;
 }
 

--- a/lib/App/Sysadmin/Log/Simple/Http.pm
+++ b/lib/App/Sysadmin/Log/Simple/Http.pm
@@ -2,6 +2,7 @@ package App::Sysadmin::Log::Simple::Http;
 use strict;
 use warnings;
 use Carp;
+use LWP::UserAgent;
 #use autodie qw(:socket); # fail, i dont know how to use autodie
 
 my $HTTP_TIMEOUT = 10;

--- a/lib/App/Sysadmin/Log/Simple/Http.pm
+++ b/lib/App/Sysadmin/Log/Simple/Http.pm
@@ -76,7 +76,7 @@ sub log {
 
         my $uri = $self->{http}->{uri};
         $uri .= ($uri =~ m/\?/) ? '&' : '?';
-        $uri .= sprintf('user=%s&log=%s',$self->{user},$logentry); #FIXME these need to be escapted
+        $uri .= sprintf('user=%s&log=%s',$self->{user},$logentry); #FIXME these need to be escaped
 
         $res = $ua->get($uri);
 

--- a/lib/App/Sysadmin/Log/Simple/Http.pm
+++ b/lib/App/Sysadmin/Log/Simple/Http.pm
@@ -1,0 +1,98 @@
+package App::Sysadmin::Log::Simple::Http;
+use strict;
+use warnings;
+use Carp;
+#use autodie qw(:socket); # fail, i dont know how to use autodie
+
+my $HTTP_TIMEOUT = 10;
+
+# ABSTRACT: a HTTP (maybe RESTful?) based logger for App::Sysadmin::Log::Simple
+# VERSION
+
+=head1 DESCRIPTION
+
+This provides a log method that sends the log via a HTTP request. Which
+may perhaps be considered to be a 'REST' request. Put, Get and Post are
+will work. Though you might not be shown to be sane for doing so.
+
+=head1 METHODS
+
+=head2 new
+
+This creates a new App::Sysadmin::Log::Simple::Http object. It takes a hash
+of options:
+
+=head3 http
+
+A hashref containing keys:
+
+=over 4
+
+=item uri - default: http://localhost
+
+=item method - default: post
+
+=back
+
+=head3 user
+
+The user to attribute the log entry to (not http user)
+
+=cut
+
+sub new {
+    my $class = shift;
+    my %opts  = @_;
+    my $app   = $opts{app};
+
+    $app->{http}->{uri} ||= 'http://localhost';
+    $app->{http}->{method} ||= 'post';
+
+    return bless {
+        do_http => $app->{do_http},
+        http    => $app->{http},
+        user    => $app->{user},
+    }, $class;
+}
+
+=head2 log
+
+This connects to the remote server and sends the log entry out.
+
+=cut
+
+sub log {
+    my $self     = shift;
+    my $logentry = shift;
+
+    return unless $self->{do_http};
+
+    my $ua = LWP::UserAgent->new;
+    $ua->timeout($HTTP_TIMEOUT);
+    my $res;
+
+    if ( lc $self->{http}->{method} eq 'get' ) {
+
+        my $uri = $self->{http}->{uri};
+        $uri .= ($uri =~ m/\?/) ? '&' : '?';
+        $uri .= sprintf('user=%s&log=%s',$self->{user},$logentry); #FIXME these need to be escapted
+
+        $res = $ua->get($uri);
+
+    } elsif ( lc $self->{http}->{method} eq 'post' ) {
+
+        $res = $ua->post($self->{http}->{uri}, { user => $self->{user}, log => $logentry });
+
+    } elsif ( lc $self->{http}->{method} eq 'put' ) {
+
+        $res = $ua->put($self->{http}->{uri}, { user => $self->{user}, log => $logentry });
+
+    }
+
+    carp sprintf('Failed to http log via %s to %s with code %d and error %s',
+		$self->{http}->{method},$self->{http}->{uri},$res->code,$res->status_line);
+
+    return "Logged to $self->{http}->{uri} via $self->{http}->{method}"
+}
+
+1;


### PR DESCRIPTION
Here is a http plugin function. The user/admin is able to send the log message via HTTP (which could also be called RESTful). Optionally using get, post or push method. Ive used LWP, as HTTP::Tiny doesnt (seem) to have PUT and PUSH functions.

To be really useful, the log program would also be able to read back the logs via HTTP. Also a config file so that logging is quicker, otherwise the command line options become a big burden on making a quick log message!
